### PR TITLE
Dockerfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ asset/.DS_Store
 asset/examples/.DS_Store
 asset/examples/hdri_examples/.DS_Store
 asset/examples/image_examples/.DS_Store
+__pycache__/
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,31 +17,50 @@
 FROM nvcr.io/nvidia/pytorch:24.10-py3
 
 # Install basic tools
-RUN apt-get update && apt-get install -y git tree ffmpeg wget
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh && ln -s /lib64/libcuda.so.1 /lib64/libcuda.so
+RUN apt-get update && apt-get install -y git tree ffmpeg wget && \
+    rm /bin/sh && ln -s /bin/bash /bin/sh && ln -s /lib64/libcuda.so.1 /lib64/libcuda.so
 
 # Copy the cosmos-predict1.yaml and requirements.txt files to the container
+# cosmos predict yaml installs cuda 12.4 base image is on cuda 12.6
 COPY ./cosmos-predict1.yaml /cosmos-predict1.yaml
 COPY ./requirements.txt /requirements.txt
 
-# Install cosmos-predict1 dependencies. This will take a while.
+ENV CONDA_DIR=/opt/conda
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH=${CONDA_DIR}/bin:${PATH}
+ENV ENVNAME=cosmos-predict1
+ENV ENVDIR=${CONDA_DIR}/envs/${ENVNAME}
+ENV CUDA_HOME=${ENVDIR}
+ENV CONDA_ACCEPT_TERMS=true
+ENV PATH=${ENVDIR}/bin:${PATH}
+
 RUN echo "Installing dependencies. This will take a while..." && \
-    mkdir -p ~/miniconda3 && \
-    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh && \
-    bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3 && \
-    rm ~/miniconda3/miniconda.sh && \
-    source ~/miniconda3/bin/activate && \
-    conda env create --file /cosmos-predict1.yaml && \
-    conda activate cosmos-predict1 && \
+    rm -rf ${CONDA_DIR} /tmp/mamba.sh && \
+    mkdir -p ${CONDA_DIR} && \
+    wget --no-hsts --quiet "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O /tmp/mamba.sh && \
+    /bin/bash /tmp/mamba.sh -b -u -p ${CONDA_DIR} && \
+    rm /tmp/mamba.sh && \
+    conda clean --tarballs --index-cache --packages --yes && \
+    find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
+    find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
+    conda clean --force-pkgs-dirs --all --yes 
+
+# use bash for subsequent RUN, no need to do RUN /bin/bash -c 
+SHELL ["/bin/bash", "-c"]
+
+RUN mamba env create --file /${ENVNAME}.yaml && \
+    source ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate ${ENVNAME} && \
     pip install --no-cache-dir -r /requirements.txt && \
-    ln -sf $CONDA_PREFIX/lib/python3.10/site-packages/nvidia/*/include/* $CONDA_PREFIX/include/ && \
-    ln -sf $CONDA_PREFIX/lib/python3.10/site-packages/nvidia/*/include/* $CONDA_PREFIX/include/python3.10 && \
-    ln -sf $CONDA_PREFIX/lib/python3.10/site-packages/triton/backends/nvidia/include/* $CONDA_PREFIX/include/ && \
+    ln -sf ${ENVDIR}/lib/python3.10/site-packages/nvidia/*/include/* ${ENVDIR}/include/ && \
+    ln -sf ${ENVDIR}/lib/python3.10/site-packages/nvidia/*/include/* ${ENVDIR}/include/python3.10 && \
+    ln -sf ${ENVDIR}/lib/python3.10/site-packages/triton/backends/nvidia/include/* ${ENVDIR}/include/ && \
     pip install transformer-engine[pytorch]==1.12.0 && \
-    git clone https://github.com/NVIDIA/apex && cd apex && \
-    CUDA_HOME=$CONDA_PREFIX pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" . && \
-    echo "Environment setup complete"
+    git clone https://github.com/NVIDIA/apex && \
+    ln -sf ${ENVDIR}/lib/python3.10/site-packages/triton/backends/nvidia/include/crt ${ENVDIR}/include/ && \
+    pip install git+https://github.com/NVlabs/nvdiffrast.git && \
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate ${ENVNAME}" >> /etc/skel/.bashrc && \
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate ${ENVNAME}" >> ~/.bashrc 
 
+ENV PATH=${ENVDIR}/bin:${PATH}
 
-# Default command
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,12 +65,4 @@ RUN mamba env create --file /${ENV_NAME}.yaml && \
 RUN echo "export CUDA_HOME=${ENV_DIR} " >> ${ENV_DIR}/etc/conda/activate.d/env_vars.sh && \
     echo "export CUDA_HOME=/usr/local/cuda" >> ${ENV_DIR}/etc/conda/deactivate.d/env_vars.sh
 
-## build passing path
-# docker build --build-arg DOCKERFILE="$(pwd)/Dockerfile" -f Dockerfile . -t nvidia/xvdp/cosmos-predict1:latest
-# docker inspect --format='{{index .Config.Labels "dockerfile"}}' nvidia/xvdp/cosmos-predict1:latest
-ARG DOCKERFILE
-LABEL dockerfile="${DOCKERFILE}"
-# run 
-    # docker run --gpus device=1 --cpuset-cpus=0-10 --network=host  -it --rm --shm-size 30g -v `pwd`:/app --workdir /app -e TORCH_EXTENSIONS_DIR=/app/tmp nvidia/xvdp/cosmos-predict1:latest
-
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,15 @@ RUN mamba env create --file /${ENV_NAME}.yaml && \
     echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate ${ENV_NAME}" >> ~/.bashrc
 
 # switch CUDA_HOME inside environemnt, without changing HOME in default environemnt
-RUN echo "export CUDA_HOME=${ENV_DIR}:${CUDA_HOME} " >> ${ENV_DIR}/etc/conda/activate.d/env_vars.sh && \
-    echo "export CUDA_HOME=$(echo $CUDA_HOME | sed 's|${ENV_DIR}:||') " >> ${ENV_DIR}/etc/conda/deactivate.d/env_vars.sh
+RUN echo "export CUDA_HOME=${ENV_DIR} " >> ${ENV_DIR}/etc/conda/activate.d/env_vars.sh && \
+    echo "export CUDA_HOME=/usr/local/cuda" >> ${ENV_DIR}/etc/conda/deactivate.d/env_vars.sh
+
+## build passing path
+# docker build --build-arg DOCKERFILE="$(pwd)/Dockerfile" -f Dockerfile . -t nvidia/xvdp/cosmos-predict1:latest
+# docker inspect --format='{{index .Config.Labels "dockerfile"}}' nvidia/xvdp/cosmos-predict1:latest
+ARG DOCKERFILE
+LABEL dockerfile="${DOCKERFILE}"
+# run 
+    # docker run --gpus device=1 --cpuset-cpus=0-10 --network=host  -it --rm --shm-size 30g -v `pwd`:/app --workdir /app -e TORCH_EXTENSIONS_DIR=/app/tmp nvidia/xvdp/cosmos-predict1:latest
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
re. https://github.com/nv-tlabs/cosmos1-diffusion-renderer/issues/21
Docker build did not complete, fixed.

Also in this PR
* switched to mamba which is faster than conda
* added nvdiffrast to installation,
* activates (cosmos-predict1) environment on docker run, adding .bashrc 
* added CUDA_HOME switching on conda activate cosmos-predict1
* projects are compiled with Correct CUDA 12.4 in docker with temporary env
* CONDA_DIR as well to what I think is more canonical /opt/conda.

Dockerfile works and is able to run examples without extra shenaningans ( other than downloading weights) 
