### PR TITLE
Add env_rot_x / env_rot_z for 3-axis environment-light rotation

### DIFF
--- a/cosmos_predict1/diffusion/inference/diffusion_renderer_utils/rendering_utils.py
+++ b/cosmos_predict1/diffusion/inference/diffusion_renderer_utils/rendering_utils.py
@@ -113,10 +113,74 @@ def rotate_x(a, device=None):
 
 def rotate_y(a, device=None):
     s, c = np.sin(a), np.cos(a)
-    return torch.tensor([[ c, 0, s, 0], 
-                         [ 0, 1, 0, 0], 
-                         [-s, 0, c, 0], 
+    return torch.tensor([[ c, 0, s, 0],
+                         [ 0, 1, 0, 0],
+                         [-s, 0, c, 0],
                          [ 0, 0, 0, 1]], dtype=torch.float32, device=device)
+
+
+def rotate_z(a, device=None):
+    s, c = np.sin(a), np.cos(a)
+    return torch.tensor([[ c, s, 0, 0],
+                         [-s, c, 0, 0],
+                         [ 0, 0, 1, 0],
+                         [ 0, 0, 0, 1]], dtype=torch.float32, device=device)
+
+
+def rotate_xyz(rx, ry, rz, device=None):
+    """Compose an XYZ rotation matrix from three Euler angles in radians.
+    Order is rotate_z @ rotate_y @ rotate_x so axes are applied as
+    pitch -> yaw -> roll on the rotated frame, matching Three.js /
+    OrbitControls conventions.
+    """
+    if rx == 0 and ry == 0 and rz == 0:
+        return torch.eye(4, dtype=torch.float32, device=device)
+    Rx = rotate_x(rx, device=device) if rx != 0 else torch.eye(4, dtype=torch.float32, device=device)
+    Ry = rotate_y(ry, device=device) if ry != 0 else torch.eye(4, dtype=torch.float32, device=device)
+    Rz = rotate_z(rz, device=device) if rz != 0 else torch.eye(4, dtype=torch.float32, device=device)
+    return Rz @ Ry @ Rx
+
+
+def rotate_latlong(latlong_img, rot_matrix, device=None):
+    """Rotate an equirectangular HDR/LDR image (H, W, 3) by a 3x3 (or 4x4)
+    rotation matrix. For each output pixel the source direction is computed
+    by applying the inverse rotation, and the input is bilinearly resampled.
+
+    This is strictly more general than the horizontal `torch.roll` trick
+    used for yaw-only rotations in `load_and_preprocess_hdr`; use it when
+    any of the pitch / roll axes are non-zero.
+    """
+    if dr is None:
+        raise RuntimeError("rotate_latlong requires nvdiffrast.torch for lat-long sampling")
+    if rot_matrix.shape[-1] == 4:
+        R = rot_matrix[:3, :3]
+    else:
+        R = rot_matrix
+    R = R.to(device=device, dtype=torch.float32)
+
+    H, W = latlong_img.shape[:2]
+    out_dirs = latlong_vec((H, W), device=device)                  # (H, W, 3)
+    # `dir @ R` applies the inverse rotation (R is orthogonal, so R.T == inv).
+    src_dirs = out_dirs @ R                                        # (H, W, 3)
+
+    # Convert source directions back to (gx, gy) using latlong_vec's convention:
+    #   dir = (sin(theta)*sin(phi), cos(theta), -sin(theta)*cos(phi))
+    #   theta = acos(y);   phi = atan2(x, -z)
+    # `latlong_vec` maps gy ∈ [0, 1] -> theta * pi and gx ∈ [-1, 1] -> phi * pi.
+    x = src_dirs[..., 0]
+    y = src_dirs[..., 1].clamp(-1.0, 1.0)
+    z = src_dirs[..., 2]
+    theta = torch.arccos(y)
+    phi = torch.atan2(x, -z)
+    gy = theta / np.pi
+    gx = phi / np.pi
+
+    texcoord = torch.stack([gx, gy], dim=-1)[None]                 # (1, H, W, 2)
+    sampled = dr.texture(
+        latlong_img[None].contiguous(), texcoord.contiguous(), filter_mode='linear'
+    )[0]
+    return sampled
+
 
 def envmap_vec(res, device=None):
     return -latlong_vec(res, device).flip(0).flip(1) #[H, W, 3]

--- a/cosmos_predict1/diffusion/inference/diffusion_renderer_utils/utils_env_proj.py
+++ b/cosmos_predict1/diffusion/inference/diffusion_renderer_utils/utils_env_proj.py
@@ -54,6 +54,8 @@ def process_environment_map(
     env_strength=1.0,
     env_flip=True,
     env_rot=180.0,
+    env_rot_x=0.0,
+    env_rot_z=0.0,
     save_dir=None,
     prefix='0000',
     device=None,
@@ -75,7 +77,9 @@ def process_environment_map(
         log_scale (int): Log scale factor for HDR mapping.
         env_strength (float): Strength multiplier for the environment map.
         env_flip (bool): Flip the environment map horizontally if True.
-        env_rot (float): Rotation angle for the environment map in degrees.
+        env_rot (float): Yaw rotation of the environment map in degrees (Y axis).
+        env_rot_x (float): Pitch rotation of the environment map in degrees (X axis). 0 = no pitch.
+        env_rot_z (float): Roll rotation of the environment map in degrees (Z axis). 0 = no roll.
         save_dir (str): Directory to save the processed images (optional).
         prefix (str): Prefix for the output files (used if saving images).
 
@@ -115,6 +119,8 @@ def process_environment_map(
         env_strength=env_strength,
         env_flip=env_flip,
         env_rot=env_rot,
+        env_rot_x=env_rot_x,
+        env_rot_z=env_rot_z,
         device=device
     )
 
@@ -127,7 +133,9 @@ def process_environment_map(
         fixed_pose=fixed_pose,
         rotate_envlight=rotate_envlight,
         save_dir=save_dir,
-        prefix=prefix
+        prefix=prefix,
+        env_rot_x=env_rot_x,
+        env_rot_z=env_rot_z
     )
 
     # Initialize result dictionary
@@ -219,8 +227,18 @@ def prepare_camera_poses(num_frames, fixed_pose, pose_file, pose_offset, pose_re
     return c2w_list
 
 
-def load_and_preprocess_hdr(hdr_dir, env_strength, env_flip, env_rot, device):
-    """Load and preprocess the HDR environment map."""
+def load_and_preprocess_hdr(hdr_dir, env_strength, env_flip, env_rot, device,
+                            env_rot_x=0.0, env_rot_z=0.0):
+    """Load and preprocess the HDR environment map.
+
+    Rotation semantics:
+      - When only `env_rot` (yaw) is non-zero and `env_rot_x` / `env_rot_z`
+        are zero, we keep the fast horizontal pixel-roll for bitwise
+        backward compatibility.
+      - When either `env_rot_x` (pitch) or `env_rot_z` (roll) is non-zero we
+        switch to a full 3D direction-remap via `util.rotate_latlong`. This
+        also absorbs `env_rot` so all three axes compose correctly.
+    """
     latlong_img = imageio_v3.imread(hdr_dir, flags=cv2.IMREAD_UNCHANGED, plugin='opencv')
     latlong_img = torch.tensor(latlong_img, dtype=torch.float32, device=device)
     latlong_img *= env_strength
@@ -232,7 +250,16 @@ def load_and_preprocess_hdr(hdr_dir, env_strength, env_flip, env_rot, device):
     if env_flip:
         latlong_img = torch.flip(latlong_img, dims=[1])
 
-    if env_rot != 0:
+    needs_3d_rotation = env_rot_x != 0 or env_rot_z != 0
+    if needs_3d_rotation:
+        R = util.rotate_xyz(
+            np.deg2rad(env_rot_x),
+            np.deg2rad(env_rot),
+            np.deg2rad(env_rot_z),
+            device=device,
+        )
+        latlong_img = util.rotate_latlong(latlong_img, R, device=device)
+    elif env_rot != 0:
         lat_h, lat_w = latlong_img.shape[:2]
         pixel_rot = int(lat_w * env_rot / 360)
         latlong_img = torch.roll(latlong_img, shifts=pixel_rot, dims=1)
@@ -242,11 +269,15 @@ def load_and_preprocess_hdr(hdr_dir, env_strength, env_flip, env_rot, device):
     return cubemap
 
 
-def prepare_metadata(hdr_dir, env_rot, env_flip, env_strength, fixed_pose, rotate_envlight, save_dir, prefix):
+def prepare_metadata(hdr_dir, env_rot, env_flip, env_strength, fixed_pose,
+                     rotate_envlight, save_dir, prefix,
+                     env_rot_x=0.0, env_rot_z=0.0):
     """Prepare metadata about the environment map processing."""
     env_meta = {
         'envmap': os.path.basename(hdr_dir),
         'envmap_rot': env_rot,
+        'envmap_rot_x': env_rot_x,
+        'envmap_rot_z': env_rot_z,
         'envmap_flip': env_flip,
         'envmap_strength': env_strength,
         'fixed_pose': fixed_pose,


### PR DESCRIPTION
## Summary

`process_environment_map` currently only exposes `env_rot` (yaw, Y axis)
and applies it via a horizontal pixel-roll on the equirect. This PR
adds optional `env_rot_x` (pitch) and `env_rot_z` (roll) so env-light
rotations are full 3-DOF without breaking any existing call-site.

## Motivation

I'm building a 3D env-map inspector (Three.js / OrbitControls style)
that lets users drag-rotate an HDR preview sphere around all three
axes. The actual relight only picked up yaw — pitch and roll were
preview-only. Adding proper 3-axis support upstream closes that gap
and makes the helper functions useful beyond my pack.

## Changes

- **`rendering_utils.py`**
  - `rotate_z(a)` — matches the existing `rotate_x` / `rotate_y` helpers.
  - `rotate_xyz(rx, ry, rz)` — composes `Rz @ Ry @ Rx` (the convention
    used by Three.js / OrbitControls and typical Euler-viewer UIs).
    Identity fast-path when all three angles are zero.
  - `rotate_latlong(img, R)` — rotates an equirect (H, W, 3) by a 3x3
    or 4x4 rotation matrix via source-direction remap + `dr.texture`
    bilinear sampling.
- **`utils_env_proj.py`**
  - `load_and_preprocess_hdr` gains `env_rot_x=0.0` and `env_rot_z=0.0`
    keyword args.
  - When both are 0 the existing `env_rot` pixel-roll path is used
    bitwise-identically (backward compatible).
  - When either is non-zero the code switches to the full 3D rotation
    via `rotate_latlong`, composing all three axes into one matrix.
  - `process_environment_map` plumbs the new args through to
    `load_and_preprocess_hdr` and `prepare_metadata`.

## Backward compatibility

Every new parameter defaults to `0.0`. Existing workflows that only set
`env_rot` hit the original `torch.roll` branch and produce identical
output. No CLI flags are introduced.

## Test plan

- [ ] Existing `inference_forward_renderer.py` run (yaw-only) produces
      pixel-identical output to `main`.
- [ ] `process_environment_map(..., env_rot_x=30.0)` produces a
      visibly tilted HDR and the resulting relight shows the sun
      lower/higher accordingly.
- [ ] `process_environment_map(..., env_rot_z=45.0)` produces a
      visibly rolled HDR.
- [ ] Triple-axis input composes cleanly (no interaction with the old
      yaw-only pixel-roll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)